### PR TITLE
feat: use the HEAD method to retrieve the Content-Type information

### DIFF
--- a/.github/workflows/update-backend.yml
+++ b/.github/workflows/update-backend.yml
@@ -30,4 +30,4 @@ jobs:
             push: true
             tags: beclab/recommend-backend:${{ github.event.inputs.tags }}
             file: Dockerfile.backend
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64

--- a/.github/workflows/update-backend.yml
+++ b/.github/workflows/update-backend.yml
@@ -30,4 +30,4 @@ jobs:
             push: true
             tags: beclab/recommend-backend:${{ github.event.inputs.tags }}
             file: Dockerfile.backend
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64

--- a/backend-server/crawler/entry.go
+++ b/backend-server/crawler/entry.go
@@ -334,19 +334,19 @@ func defaultFetchRawContent(url string, bflUser string) (string, string, string)
 	}
 	if !isAllowedContentType(response.ContentType) {
 		common.Logger.Error("scraper: this resource is not a HTML document ", zap.String("url", url))
-		return "", fileType, fileName
+		return "", "", ""
 	}
 	if err = response.EnsureUnicodeBody(); err != nil {
 		common.Logger.Error("scraper: this response check unicodeBody error ")
-		return "", fileType, fileName
+		return "", "", ""
 	}
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		common.Logger.Error("crawling entry rawContent error ", zap.String("url", url), zap.Error(err))
-		return "", fileType, fileName
+		return "", "", ""
 	}
 	common.Logger.Info("crawle raw content", zap.Int("length:", len(body)))
-	return string(body), fileType, fileName
+	return string(body), "", ""
 }
 
 func determineFileType(reqContentType string) string {

--- a/backend-server/crawler/entry.go
+++ b/backend-server/crawler/entry.go
@@ -320,10 +320,10 @@ func defaultFetchRawContent(url string, bflUser string) (string, string, string)
 		return "", fileType, fileName
 	}
 
+	common.Logger.Info("fetch raw content ", zap.String("url", url))
 	clt := client.NewClientWithConfig(url)
 	clt.WithBflUser(bflUser)
 	response, err := clt.Get()
-	common.Logger.Info("fetch raw content finish", zap.String("url", url))
 	if err != nil {
 		common.Logger.Error("crawling entry rawContent error ", zap.String("url", url), zap.Error(err))
 		return "", "", ""

--- a/backend-server/http/client/client.go
+++ b/backend-server/http/client/client.go
@@ -170,6 +170,15 @@ func (c *Client) Get() (*Response, error) {
 	return c.executeRequest(request)
 }
 
+func (c *Client) Head() (*Response, error) {
+	request, err := c.buildRequest(http.MethodHead, nil)
+	if err != nil {
+		return nil, err
+	}
+	RequestAddCookie(request, c.inputURL, c.bflUser)
+	return c.executeRequest(request)
+}
+
 // PostForm performs a POST HTTP request with form encoded values.
 func (c *Client) PostForm(values url.Values) (*Response, error) {
 	request, err := c.buildRequest(http.MethodPost, strings.NewReader(values.Encode()))


### PR DESCRIPTION
Background
Obtain header information using the HEAD method instead of the GET method.

Related Issues
none 

Other information: 