### PR TITLE
feat: modify the Bilibili opus page scraping rules

### DIFF
--- a/.github/workflows/update-backend.yml
+++ b/.github/workflows/update-backend.yml
@@ -30,4 +30,4 @@ jobs:
             push: true
             tags: beclab/recommend-backend:${{ github.event.inputs.tags }}
             file: Dockerfile.backend
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64

--- a/.github/workflows/update-backend.yml
+++ b/.github/workflows/update-backend.yml
@@ -30,4 +30,4 @@ jobs:
             push: true
             tags: beclab/recommend-backend:${{ github.event.inputs.tags }}
             file: Dockerfile.backend
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64

--- a/backend-server/crawler/entry.go
+++ b/backend-server/crawler/entry.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/url"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"bytetrade.io/web3os/backend-server/common"
@@ -107,14 +106,14 @@ func EntryCrawler(url string, bflUser string, feedID string) *model.Entry {
 	primaryDomain := common.GetPrimaryDomain(url)
 	urlDomain := common.Domain(url)
 
-	opusPattern := `bilibili\.com/opus`
-	bilibiliOpusRe := regexp.MustCompile(opusPattern)
+	//opusPattern := `bilibili\.com/opus`
+	//bilibiliOpusRe := regexp.MustCompile(opusPattern)
 	common.Logger.Info("crawler entry start", zap.String("url", url), zap.String("primary domain:", primaryDomain))
 
 	var entry *model.Entry
 	switch primaryDomain {
 	case "bilibili.com":
-		if urlDomain == "t.bilibili.com" || bilibiliOpusRe.MatchString(url) {
+		if urlDomain == "t.bilibili.com" { //|| bilibiliOpusRe.MatchString(url) {
 			entry = handleTBilibili(url, bflUser)
 		} else {
 			entry = handleDefault(url, bflUser)

--- a/backend-server/crawler/tbilibili/client.go
+++ b/backend-server/crawler/tbilibili/client.go
@@ -127,7 +127,7 @@ func generateEntry(resp *Response) *model.Entry {
 
 	}
 	entry.Title = common.GetFirstSentence(resp.Data.Item.Modules.DynamicModule.DynamicDesc.DynamicText)
-
+	common.Logger.Error("generate bilibili entry ", zap.Int("content size", len(entry.FullContent)), zap.String("title", entry.Title))
 	return entry
 
 }

--- a/backend-server/crawler/tbilibili/client.go
+++ b/backend-server/crawler/tbilibili/client.go
@@ -163,7 +163,7 @@ func fetchPage(bflUser, websiteURL string) *Response {
 			common.Logger.Error("crawling entry rawContent error ", zap.String("url", websiteURL), zap.Error(err))
 			return nil
 		}
-
+		common.Logger.Error("bilibili crawler ", zap.String("url", websiteURL), zap.String("content", string(body)))
 		var data Response
 		if err := json.Unmarshal(body, &data); err != nil {
 			return nil

--- a/backend-server/crawler/ytdlp/client.go
+++ b/backend-server/crawler/ytdlp/client.go
@@ -29,7 +29,7 @@ func IsMetaFromYtdlp(url string) bool {
 }
 
 func Fetch(bflUser, url string) *model.Entry {
-	apiUrl := common.YTDLPApiUrl() + "/v1/get_metadata?url=" + url + "&bfl_user=" + bflUser
+	apiUrl := common.YTDLPApiUrl() + "/v1/get_metadata?bfl_user=" + bflUser + "&url=" + url
 	common.Logger.Info("load meta from ytdlp", zap.String("url", apiUrl))
 	client := &http.Client{Timeout: time.Second * 50}
 	res, err := client.Get(apiUrl)

--- a/backend-server/go.mod
+++ b/backend-server/go.mod
@@ -18,7 +18,7 @@ require (
 
 require (
 	github.com/PuerkitoBio/goquery v1.9.1
-	github.com/beclab/article-extractor v0.0.57
+	github.com/beclab/article-extractor v0.0.58
 	github.com/chromedp/cdproto v0.0.0-20250222051814-50c6cb17f10a
 	github.com/chromedp/chromedp v0.13.0
 	github.com/gorilla/mux v1.8.1

--- a/backend-server/go.sum
+++ b/backend-server/go.sum
@@ -72,8 +72,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/beclab/article-extractor v0.0.57 h1:HQz4j6c/NT7qt9Pwye6wu7Lv+gmooI41Kk1W1u0keyM=
-github.com/beclab/article-extractor v0.0.57/go.mod h1:IdJtN1EzwGfFNY1Ly+unYXhEIwxTV1yD/u3Jj9jmh18=
+github.com/beclab/article-extractor v0.0.58 h1:l9Vh1qtHm1bIJ80jAoJSIBKuu6wQv4o0kCBzFa8BB6c=
+github.com/beclab/article-extractor v0.0.58/go.mod h1:IdJtN1EzwGfFNY1Ly+unYXhEIwxTV1yD/u3Jj9jmh18=
 github.com/beclab/fs-lib v0.0.2 h1:NGsbNSt3wLweJgFW3gOBz9UyLoe4L8VTNKxIJOTgN2Y=
 github.com/beclab/fs-lib v0.0.2/go.mod h1:7MvnhYdMGnFiQBl96B1g5IGeZ0jM+p501ip2T+ZxR+I=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=

--- a/backend-server/http/client/cookie.go
+++ b/backend-server/http/client/cookie.go
@@ -73,7 +73,7 @@ func LoadCookieInfo(bflUser string, host string) []model.SettingDomainRespModel 
 	common.Logger.Info("start load cookie info ", zap.String("host", host))
 	request, _ := http.NewRequest("POST", settingUrl, bytes.NewBuffer(reqJsonByte))
 	request.Header.Set("Content-Type", "application/json")
-	//request.Header.Set("Cookie", "auth_token=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3ODA2NDYxNzksImlhdCI6MTc0OTExMDE3OSwidXNlcm5hbWUiOiJtbWNob25nMjAyMSIsImdyb3VwcyI6WyJsbGRhcF9hZG1pbiJdfQ.JqdLAMd4SAWFdatKSyXninS98DmTvy9FXn_ma6sKHXBM1YrOiQGlZhZdY3OjU9-rdY3pfj8tqPvYhiFZWa_0nw; authelia_session=Dhwb#bgNT4SqteKabN$GN-VIgq1Lm^8U")
+	//request.Header.Set("Cookie", "auth_token=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE3NTY4MDg0MzYsImlhdCI6MTc1NjcyMjAzNiwidXNlcm5hbWUiOiJtbWNob25nMjAyMSIsImdyb3VwcyI6WyJsbGRhcF9hZG1pbiJdLCJtZmEiOjEsImppZCI6MTA2ODQ4Mjk4Mzc2NTcwMTQ3NDN9._WevGoSKE4zoDlwXlzjltuOmVoZpj8uagZghjWohg_kj0VcfJ6vL0Y62oW1L8QEuhYrmluxLarfzPj5bdQg8Ow; authelia_session=Dhwb#bgNT4SqteKabN$GN-VIgq1Lm^8U")
 
 	client := &http.Client{Timeout: time.Second * 5}
 	response, err := client.Do(request)

--- a/backend-server/knowledge/api.go
+++ b/backend-server/knowledge/api.go
@@ -38,6 +38,9 @@ func getDownloadFromEntry(entry *model.Entry, feed *model.Feed, store *storage.S
 	download.DataSource = entry.DownloadFileUrl
 	download.DownloadAPP = common.FeedSource
 	download.FileName = entry.DownloadFileName
+	if download.FileName == "" {
+		download.FileName = entry.Title
+	}
 	download.FileType = entry.DownloadFileType
 	download.BflUser = entry.BflUser
 	download.EntryId = entry.ID

--- a/backend-server/service/feed.go
+++ b/backend-server/service/feed.go
@@ -133,7 +133,7 @@ func RefreshFeed(store *storage.Storage, feedID string) {
 		updateFeedIconByIconUrl(originalFeed, avatar)
 	case strings.HasPrefix(feedUrl, "youtube://"):
 		feedUrl = strings.Replace(feedUrl, "youtube://", "https://www.youtube.com/", 1)
-		updatedFeed, avatar = RefreshYoutubeFeed(store, feedUrl, originalFeed.ID)
+		updatedFeed, avatar = RefreshYoutubeFeed(store, feedUrl, originalFeed.ID, originalFeed.BflUser)
 		updateFeedIconByIconUrl(originalFeed, avatar)
 	default:
 		updatedFeed = handleDefaultFeed(store, originalFeed, feedUrl)

--- a/backend-server/service/youtube.go
+++ b/backend-server/service/youtube.go
@@ -45,8 +45,8 @@ func GetEntryFromYoutubeEntry(youtubeEntry YoutubeResponseItem, author string) *
 	return &entry
 }
 
-func youtubeFeedRefreshExec(url string, start int, limit int) YoutubeListResponse {
-	youtubeListUrl := common.YTDLPApiUrl() + "/v1/get_youtube_entry_list?" + fmt.Sprintf("url=%s&start=%d&limit=%d", url, start, limit)
+func youtubeFeedRefreshExec(url string, start int, limit int, bfl_user string) YoutubeListResponse {
+	youtubeListUrl := common.YTDLPApiUrl() + "/v1/get_youtube_entry_list?" + fmt.Sprintf("url=%s&start=%d&limit=%d&bfl_user=%s", url, start, limit, bfl_user)
 	client := &http.Client{Timeout: time.Second * 60}
 	common.Logger.Info("youtube start get list:" + url)
 	var responseData YoutubeListResponse
@@ -69,7 +69,7 @@ func youtubeFeedRefreshExec(url string, start int, limit int) YoutubeListRespons
 	return responseData
 
 }
-func RefreshYoutubeFeed(store *storage.Storage, url string, feedID string) (*model.Feed, string) {
+func RefreshYoutubeFeed(store *storage.Storage, url string, feedID string, bflUser string) (*model.Feed, string) {
 	var feed model.Feed
 	avatar := ""
 	start := 0
@@ -78,7 +78,7 @@ func RefreshYoutubeFeed(store *storage.Storage, url string, feedID string) (*mod
 		limit = 0
 	}
 	entries := make([]*model.Entry, 0)
-	responseData := youtubeFeedRefreshExec(url, start, start+limit)
+	responseData := youtubeFeedRefreshExec(url, start, start+limit, bflUser)
 	common.Logger.Info("youtube feed refresh over", zap.Any("data", responseData))
 	author := responseData.Data.Author
 	for len(responseData.Data.List) > 0 {
@@ -92,7 +92,7 @@ func RefreshYoutubeFeed(store *storage.Storage, url string, feedID string) (*mod
 		savedEntry := store.GetEntryByUrl(feedID, lastEntry.URL)
 		if limit > 0 && len(responseData.Data.List) == limit && savedEntry == nil {
 			start = start + limit
-			responseData = youtubeFeedRefreshExec(url, start, limit)
+			responseData = youtubeFeedRefreshExec(url, start, limit, bflUser)
 		} else {
 			break
 		}


### PR DESCRIPTION
Background
modify the Bilibili opus page  scraping rules without using the API.
add cookie functionality to the feed in ytdlp.

Related Issues
none 

Other information: 